### PR TITLE
Check for pre-existing settings instead of Texture Factory

### DIFF
--- a/Source/BUIValidator/Private/BUIValidatorModule.cpp
+++ b/Source/BUIValidator/Private/BUIValidatorModule.cpp
@@ -57,29 +57,25 @@ void FBUIValidatorModule::OnObjectReimported( UFactory* ImportFactory, UObject* 
 		return;
 
 	// Only apply defaults to newly-imported assets
-	UTextureFactory* TextureFactory = Cast<UTextureFactory>( ImportFactory );
-	if ( !TextureFactory->bUsingExistingSettings )
+	const UBUIValidatorSettings& ValidatorSettings = *GetDefault<UBUIValidatorSettings>();
+	for ( const auto& Group : ValidatorSettings.ValidationGroups )
 	{
-		const UBUIValidatorSettings& ValidatorSettings = *GetDefault<UBUIValidatorSettings>();
-		for ( const auto& Group : ValidatorSettings.ValidationGroups )
+		if ( Group.bApplyOnImport
+			&& Group.ShouldGroupValidateAsset( InObject ) )
 		{
-			if ( Group.bApplyOnImport
-				&& Group.ShouldGroupValidateAsset( InObject ) )
+			if ( Group.ValidationRule.TextureGroups.Num() > 0 && !Group.ValidationRule.TextureGroups.Contains( Texture->LODGroup ) )
 			{
-				if ( Group.ValidationRule.TextureGroups.Num() > 0 )
-				{
-					Texture->LODGroup = Group.ValidationRule.TextureGroups[ 0 ];
-				}
+				Texture->LODGroup = Group.ValidationRule.TextureGroups[ 0 ];
+			}
 
-				if ( Group.ValidationRule.CompressionSettings.Num() > 0 )
-				{
-					Texture->CompressionSettings = Group.ValidationRule.CompressionSettings[ 0 ];
-				}
+			if ( Group.ValidationRule.CompressionSettings.Num() > 0 && !Group.ValidationRule.CompressionSettings.Contains( Texture->CompressionSettings ) )
+			{
+				Texture->CompressionSettings = Group.ValidationRule.CompressionSettings[ 0 ];
+			}
 
-				if ( Group.ValidationRule.MipGenSettings.Num() > 0 )
-				{
-					Texture->MipGenSettings = Group.ValidationRule.MipGenSettings[ 0 ];
-				}
+			if ( Group.ValidationRule.MipGenSettings.Num() > 0 && !Group.ValidationRule.MipGenSettings.Contains( Texture->MipGenSettings ))
+			{
+				Texture->MipGenSettings = Group.ValidationRule.MipGenSettings[ 0 ];
 			}
 		}
 	}


### PR DESCRIPTION
This fixes issue https://github.com/benui-dev/UE-BUIValidator/issues/4 by checking for pre-existing settings instead of trying to get a valid Texture Factory. Because it would likely require bigger changes if it's to work with the Interchange plugin. We check if the texture already has some settings that aren't valid and if so set the default (first) setting for each.