### PR TITLE
Improve support for content structures across game and plugins

### DIFF
--- a/Source/BUIValidator/Private/BUIValidatorSettings.cpp
+++ b/Source/BUIValidator/Private/BUIValidatorSettings.cpp
@@ -33,7 +33,9 @@ bool FBUIValidatorGroup::ShouldGroupValidateAsset( UObject* InAsset ) const
 	bool bMatchAnyPath = MatchConditions.Paths.Num() == 0;
 	for ( const auto& Path : MatchConditions.Paths )
 	{
-		if ( AssetPathInUnreal.StartsWith( Path.Path ) )
+		if ( Path.Type == EBUIPathType::StartsWith && AssetPathInUnreal.StartsWith( Path.Path ) ||
+			Path.Type == EBUIPathType::EndsWith && AssetPathInUnreal.EndsWith( Path.Path ) ||
+			Path.Type == EBUIPathType::Contains && AssetPathInUnreal.Contains( Path.Path ) )
 		{
 			bMatchAnyPath = true;
 			break;

--- a/Source/BUIValidator/Public/BUIValidatorSettings.h
+++ b/Source/BUIValidator/Public/BUIValidatorSettings.h
@@ -9,6 +9,28 @@ enum class EBUITextureSizeRequirement
 	PowerOfTwo,
 };
 
+UENUM()
+enum class EBUIPathType
+{
+	Contains,
+	EndsWith,
+	StartsWith,
+};
+
+USTRUCT( meta = ( ToolTip = " Match any part of an asset directory." ) )
+struct FBUIPathFilter
+{
+	GENERATED_BODY()
+
+	// Which part of the directory path to search in. `EndsWith` and `Contains` are useful for content plugins. `StartsWith` is the default for backwards-compatibility.
+	UPROPERTY( EditAnywhere, meta = ( DisplayName = "Path" ) )
+	EBUIPathType Type = EBUIPathType::StartsWith;
+	
+	// Match UTexture2D assets under any of these directories
+	UPROPERTY( EditAnywhere, meta = ( DisplayName = "Path segment" ) )
+	FString Path;
+};
+
 USTRUCT( meta = ( ToolTip = "All parts of a rule must pass in order for the rule to be applied" ) )
 struct FBUIMatchConditions
 {
@@ -23,8 +45,10 @@ public:
 	TArray<FString> Prefixes = { "T_UI_" };
 
 	// Match UTexture2D assets under any of these directories
-	UPROPERTY( EditAnywhere, meta = ( ContentDir, TitleProperty = "Path" ) )
-	TArray<FDirectoryPath> Paths;
+	UPROPERTY( EditAnywhere, meta = ( TitleProperty = "Path" ) )
+	TArray<FBUIPathFilter> Paths = {
+		{ EBUIPathType::EndsWith, "/UI/" }
+	};
 };
 
 USTRUCT()

--- a/Source/BUIValidator/Public/BUIValidatorSettings.h
+++ b/Source/BUIValidator/Public/BUIValidatorSettings.h
@@ -47,7 +47,7 @@ public:
 	// Match UTexture2D assets under any of these directories
 	UPROPERTY( EditAnywhere, meta = ( TitleProperty = "Path" ) )
 	TArray<FBUIPathFilter> Paths = {
-		{ EBUIPathType::EndsWith, "/UI/" }
+		{ EBUIPathType::Contains, "/UI/" }
 	};
 };
 


### PR DESCRIPTION
## Intention

Paths that match with `StartWith` requires us to add a new path for every plugin with content. The Modular Game Features plugin type in UE5 promotes a project structure with multiple plugins, and it quickly becomes cumbersome (and easy to forget) to configure new paths.

By also supporting `EndsWith` and `Contains` as path match conditions it's now easy to set up conditions that works across both game content and plugin content directories.

## Demo

The match conditions path array is now two options instead of one path string. Unfortunately I had to remove the `ContentDir` meta. The default is one element of `Contains` `/UI/`:
![image](https://github.com/seriema/UE-BUIValidator/assets/693684/515919ed-6e86-423e-af73-f2d651e8cecd)

This allows us to use one filter instead of multiple.
![image](https://github.com/seriema/UE-BUIValidator/assets/693684/f4ea3e3a-24d9-4235-a6b4-7b326e8520cf)

## Backwards compatibility

Having created a config before making these changes I could validate that it plays nicely with previous versions of the plugin.

The default `StartsWith` lets the path match as expected:
![image](https://github.com/seriema/UE-BUIValidator/assets/693684/84086409-6d30-46b1-93dc-669b9dd862e8)

The `DefaultGame.ini` only changes if something other than the pre-existing paths change. Here I added a new path with `Contains` to show how it diffs:
![image](https://github.com/seriema/UE-BUIValidator/assets/693684/e2512b79-0407-4023-83c3-973b804894ca)

## Questions

1. I'm not happy with the naming, especially on the "Path" vs "Path segment" part. Any suggestions?
2. Should I/we do the same change to the ValidationRule/Paths?
3. I could probably make it so the config UI uses the `ContentDir` when selecting `StartsWith`, but it'd make the code much more complicated. Is it worth it?