### PR TITLE
Add validation for `Filter` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ could be allowed to be within World or UI. To pass, the asset must match
   Compression Settings.
 * **Pixel Formats:** Textures must have one of these Pixel Formats
 * **Mip Gen Settings:** Textures must have one of these Mip Gen Settings
+* **Texture Filters:**Textures must have one of these Filters
 * **Prefixes:** Textures must have one of these prefixes.
 * **Texture Size:** Textures must pass these size requirements. Size
   requirements are "Multiple of Four" or "Power of Two"

--- a/Source/BUIValidator/Private/BUIEditorValidator_Textures.cpp
+++ b/Source/BUIValidator/Private/BUIEditorValidator_Textures.cpp
@@ -119,6 +119,26 @@ EDataValidationResult UBUIEditorValidator_Textures::ValidateLoadedAsset_Implemen
 					}
 				}
 
+				if ( Group.ValidationRule.TextureFilters.Num() )
+				{
+					bAnyChecked = true;
+					if ( !Group.ValidationRule.TextureFilters.Contains( Texture->Filter ) )
+					{
+						bAnyFailed = true;
+						TArray<FString> TextureFilterNames;
+						UEnum* TextureFiltersEnum = StaticEnum<TextureFilter>();
+						for ( const auto& TextureFilter : Group.ValidationRule.TextureFilters )
+						{
+							TextureFilterNames.Add( TextureFiltersEnum->GetMetaData( TEXT( "DisplayName" ), TextureFilter ) );
+						}
+						AssetFails( InAsset, FText::Format(
+							LOCTEXT( "BUIValidatorError_TextureFilter", "Texture asset filter settings must be '{0}', but is '{1}'" ),
+							FText::FromString( FString::Join( TextureFilterNames, TEXT( ", " ) ) ),
+							FText::FromString( TextureFiltersEnum->GetMetaData( TEXT( "DisplayName" ), Texture->Filter ) ) ),
+							ValidationErrors );
+					}
+				}
+
 				if ( Group.ValidationRule.TextureSizeRequirements.Num() > 0 )
 				{
 					bAnyChecked = true;

--- a/Source/BUIValidator/Public/BUIValidatorSettings.h
+++ b/Source/BUIValidator/Public/BUIValidatorSettings.h
@@ -82,6 +82,10 @@ public:
 	UPROPERTY( config, EditAnywhere )
 	TArray<TEnumAsByte<TextureMipGenSettings>> MipGenSettings = { TextureMipGenSettings::TMGS_FromTextureGroup };
 
+	// Textures must have one of these filter settings
+	UPROPERTY( config, EditAnywhere )
+	TArray<TEnumAsByte<TextureFilter>> TextureFilters = { TextureFilter::TF_Default };
+
 	// Textures must have one of these prefixes. Is not applied on import
 	UPROPERTY( config, EditAnywhere )
 	TArray<FString> Prefixes = { "T_UI_" };


### PR DESCRIPTION
The `Filter` setting is very important for pixel art and blocky UI textures. It has to be set to `Nearest` to avoid blurriness when scaling. Other games might want other settings, so the default value is `TF_Default` (`"Default (from Texture Group)"`):

![image](https://github.com/seriema/UE-BUIValidator/assets/693684/f5b5c349-c639-4dff-b929-8f8779af0e00)

It's under the Validation Rules:

![image](https://github.com/seriema/UE-BUIValidator/assets/693684/c746bd36-3915-4b9a-9b33-6bfaaa9e7e86)

> Note about `Nearest`: The art itself should follow the "Base-4 rule" but validating that would require a very different tool than BUIValidator. So assuming the UI artist made the art, then this validator can check that the scaling will apply Nearest.